### PR TITLE
fix: extract 1st part of datasetId when an UUID

### DIFF
--- a/nifi-ngsild-postgresql-processors/src/main/java/egm/io/nifi/processors/ngsild/PostgreSQLTransformer.java
+++ b/nifi-ngsild-postgresql-processors/src/main/java/egm/io/nifi/processors/ngsild/PostgreSQLTransformer.java
@@ -21,6 +21,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static egm.io.nifi.processors.ngsild.model.NgsiLdConstants.GENERIC_MEASURE;
@@ -29,6 +30,9 @@ import static egm.io.nifi.processors.ngsild.model.PostgreSQLConstants.POSTGRESQL
 public class PostgreSQLTransformer {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgreSQLTransformer.class);
+
+    Pattern UUID_REGEX =
+        Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
     public Map<String, POSTGRESQL_COLUMN_TYPES> listOfFields(
         Entity entity,
@@ -116,10 +120,14 @@ public class PostgreSQLTransformer {
     }
 
     private String encodeAttributeToColumnName(String attributeName, String datasetId, String datasetIdPrefixToTruncate) {
+        String datasetIdWithoutPrefix = datasetId.replaceFirst(datasetIdPrefixToTruncate, "");
+        if (UUID_REGEX.matcher(datasetIdWithoutPrefix).matches())
+            datasetIdWithoutPrefix = datasetIdWithoutPrefix.substring(0, 8);
+
         // For too long dataset ids, truncate to 32 (not perfect, nor totally bulletproof)
         String datasetIdEncodedValue =
             (!datasetId.isEmpty() ?
-                "_" + PostgreSQLUtils.encodePostgreSQL(PostgreSQLUtils.truncateToSize(datasetId.replaceFirst(datasetIdPrefixToTruncate, ""), 32)) :
+                "_" + PostgreSQLUtils.encodePostgreSQL(PostgreSQLUtils.truncateToSize(datasetIdWithoutPrefix, 32)) :
                 ""
             );
         String encodedName = PostgreSQLUtils.encodePostgreSQL(attributeName) + datasetIdEncodedValue;


### PR DESCRIPTION
When a `datasetId` is composed using an UUID (eg. `urn:ngsi-ld:Dataset:7925e84f-004a-406c-b6c9-25f9733db303`), we are using `7925e84f-004a-406c-b6c9-25f9733db303` to compose the column name. Which already takes 37 characters out of the 64 that can be used for the name of a column.

So, when an UUID is detected, just keep the 1st part of it (eg. `7925e84f`). Which raises a bit the risk of conflicting names, but this should be acceptable.